### PR TITLE
add lodash to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "patrun",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1469,9 +1469,8 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "http://localhost:4873/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-driver": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "Adrien Becchis (https://github.com/AdrieanKhisbe)"
   ],
   "dependencies": {
-    "gex": "^1.0.0"
+    "gex": "^1.0.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@hapi/code": "^7.0.0",


### PR DESCRIPTION
node v12.13.1
npm v6.12.1

npm init
npm i patrun

```js
// index.js
var patrun = require('patrun')

var pm = patrun()
      .add({a:1},'A')
      .add({b:2},'B')

// prints A
console.log( pm.find({a:1}) )

// prints null
console.log( pm.find({a:2}) )

// prints A, b:1 is ignored, it was never registered
console.log( pm.find({a:1,b:1}) )

// prints B, c:3 is ignored, it was never registered
console.log( pm.find({b:2,c:3}) )
```

node index

```
Error: Cannot find module 'lodash'
```